### PR TITLE
use hash instead of url params

### DIFF
--- a/src/lib/QueryBuilder.svelte
+++ b/src/lib/QueryBuilder.svelte
@@ -40,7 +40,7 @@
 	let iframeContainer;
 
 	function buildQuery() {
-		return `${base}/${selectedViewer.id}?&manifest=${manifestURI}&theme=${selectedTheme.toLowerCase()}`;
+		return `${base}/${selectedViewer.id}#&manifest=${manifestURI}&theme=${selectedTheme.toLowerCase()}`;
 	}
 
 	function clearManifest() {

--- a/src/routes/mirador.svelte
+++ b/src/routes/mirador.svelte
@@ -1,13 +1,14 @@
+
+
 <script>
 	import { onMount } from 'svelte';
-	import { page } from '$app/stores';
 
 	onMount(async () => {
 		const Mirador = await import('mirador/dist/mirador.min.js');
-
-		const manifestID = $page.query.get('manifest');
-		const theme = $page.query.get('theme');
-
+		const hash = window.location.hash
+		const params = new URLSearchParams(hash.slice(1))
+		const manifestId = params.get('manifest')
+		const theme = params.get('theme')
 		const miradorInstance = Mirador.viewer({
 			id: 'mirador',
 			selectedTheme: theme,
@@ -30,7 +31,7 @@
 			},
 			windows: [
 				{
-					manifestId: manifestID
+					manifestId
 				}
 			]
 		});


### PR DESCRIPTION
Cut and pasted from slack:

Can’t say I fully understand this--specifically, why it runs successfully in preview--but after poking a bit my guess seems like you might conceptually want to use a URL hash instead of a parameter string to construct the URL.  
https://stackoverflow.com/questions/20751301/how-can-i-get-query-strings-in-my-amazon-s3-static-website
This isn’t fully necessary--you could keep the question mark and parse out window.location.search the same way I do window.location.hash in the pull request I just filed--but my instinct is that the general idea is that query strings are for server-side page configuration and location hashes are for client-side page configuration. if using query strings in sveltekit, it makes sense to do it inside a <script context=“module”> block, not inside the client-side <script> block; and svelte-kit refuses to build a dynamic query string for a static web page, because it implies a server.
